### PR TITLE
Disable `no-prototype-builtins` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     'react/forbid-prop-types': 0,
     'react/prefer-stateless-function': [1, { 'ignorePureComponents': true }],
     'no-mixed-operators': 0,
+    'no-prototype-builtins': 0,
     'array-callback-return': 0,
     'global-require': 0,
     'import/no-dynamic-require': 0,


### PR DESCRIPTION
Проверка
```js
global.hasOwnProperty('myProp')
```
провоцирует ошибку eslint, всвязи со включенным правилом `no-prototype-builtins`
```sh
$> Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
```
требуя использовать нотацию
```js
Object.prototype.hasOwnProperty.call(window, 'myProp')
```

однако
```js
Object.prototype.hasOwnProperty.call(undefined, 'myProp')
```
бросит ошибку 
```sh
TypeError: Cannot convert undefined or null to object
```
что делает это правило вдвойне бесполезным