### PR TITLE
Allow backtick to escape single-quote string values

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
   },
   rules: {
     semi: [2, 'never'],
+    quotes: [2, 'single', { allowTemplateLiterals: true }],
     'func-names': 0,
     'no-underscore-dangle': 0,
     'arrow-parens': [2, 'always'],


### PR DESCRIPTION
Текущее поведение:
```js
const chType = `Nullable(Enum8('site_d' = 0, 'site_t' = 1, 'site_m' = 2))`
```
```js
error    Strings must use singlequote    quotes
```
[`allowTemplateLiterals`](https://eslint.org/docs/rules/quotes#allowtemplateliterals) позволяет помимо одинарных кавычек, обьявлять строки ещё и через Template-string, без шаблонной составляющей

Необходимо дать возможность использовать Template-string в т.ч. и для эскейпинга одинарных кавычек

Сейчас у нас унаследовано правило `quotes: [2, 'single']`, но я не смог найти откуда оно унаследовалось 