### PR TITLE
Add rules for lodash imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ const rules = [
   './rules/imports.yml',
   './rules/react-jsx.yml',
   './rules/flow.yml',
+  './rules/lodash.yml',
 ]
 
 module.exports = {
@@ -15,6 +16,7 @@ module.exports = {
   parser: 'babel-eslint',
   plugins: [
     'flowtype',
+    'lodash',
   ],
   env: {
     browser: true,

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "eslint-plugin-flowtype": "3.4.2",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.0.3",
+    "eslint-plugin-lodash": "^5.1.0",
     "eslint-plugin-promise": "4.0.1",
     "eslint-plugin-react": "7.11.1"
   },
   "devDependencies": {
-    "eslint-plugin-lodash": "^5.1.0",
     "husky": "^1.2.1",
     "jest": "^24.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-react": "7.11.1"
   },
   "devDependencies": {
+    "eslint-plugin-lodash": "^5.1.0",
     "husky": "^1.2.1",
     "jest": "^24.8.0"
   },

--- a/rules/lodash.yml
+++ b/rules/lodash.yml
@@ -1,0 +1,2 @@
+rules:
+  lodash/import-scope: ["error", "method"]

--- a/tests/lodash-imports.js
+++ b/tests/lodash-imports.js
@@ -1,0 +1,39 @@
+const { CLIEngine } = require('eslint')
+
+const cli = new CLIEngine({ ignore: false })
+
+const validSnippet = `
+/* eslint import/no-extraneous-dependencies: 0, no-console: 0 */
+import get from 'lodash/get'
+
+console.log(get)
+`
+
+const invalidSnippetWithDestructuring = `
+/* eslint import/no-extraneous-dependencies: 0, no-console: 0 */
+import { get } from 'lodash'
+
+console.log(get)
+`
+
+const invalidSnippetWithImportingLodashObject = `
+/* eslint import/no-extraneous-dependencies: 0, no-console: 0 */
+import _ from 'lodash'
+
+console.log(_)
+`
+
+test('Lints valid lodash import', () => {
+  const { results } = cli.executeOnText(validSnippet)
+  expect(results[0].messages).toHaveLength(0)
+})
+
+test('Throws error on invalid destructuring lodash import', () => {
+  const { results } = cli.executeOnText(invalidSnippetWithDestructuring)
+  expect(results[0].messages).toHaveLength(1)
+})
+
+test('Throws error when importing lodash object', () => {
+  const { results } = cli.executeOnText(invalidSnippetWithImportingLodashObject)
+  expect(results[0].messages).toHaveLength(1)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,6 +1429,13 @@ eslint-plugin-jsx-a11y@6.0.3:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^2.0.0"
 
+eslint-plugin-lodash@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-5.1.0.tgz#f7dc6c14f104cacb169a18d17c27d9c015a53924"
+  integrity sha512-mMKmf1OMLS8VExtaHCcrwBmsYIiOVYEibnAFDzXrbJdtFGOcLEw37tryN/WGYKBiJy6nAIGC43i5Wh3KA9lO2g==
+  dependencies:
+    lodash "4.17.11"
+
 eslint-plugin-promise@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz#2d074b653f35a23d1ba89d8e976a985117d1c6a2"
@@ -2924,7 +2931,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.11, lodash@^4.17.4:
+lodash@4.17.11, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/import-scope.md

```js
// Bad
import _ from 'lodash'
import { get } from 'lodash'

// Good
import get from 'lodash/get'
```